### PR TITLE
Fix zero timestamp

### DIFF
--- a/vendor/github.com/siddontang/go-mysql/replication/row_event.go
+++ b/vendor/github.com/siddontang/go-mysql/replication/row_event.go
@@ -423,6 +423,11 @@ func (e *RowsEvent) decodeValue(data []byte, tp byte, meta uint16) (v interface{
 	case MYSQL_TYPE_TIMESTAMP:
 		n = 4
 		t := binary.LittleEndian.Uint32(data)
+
+		if t == 0 { // commented by Anthony Gonzalez. Yes I know about `git blame`
+			return "0000-00-00 00:00:00", n, nil
+		}
+
 		v = time.Unix(int64(t), 0)
 	case MYSQL_TYPE_TIMESTAMP2:
 		v, n, err = decodeTimestamp2(data, meta, e.timestampStringLocation)


### PR DESCRIPTION
### Description
This PR contains bugfix for timestamp zero issue we are facing when migrating tables that get new inserts, with 0 timestamp value, which get a wrong format.

> In case this PR introduced Go code changes:

- [X] contributed code is using same conventions as original code
- [X] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
